### PR TITLE
Make shops' addresses links to open Apple/Google Maps

### DIFF
--- a/src/components/Shop/index.js
+++ b/src/components/Shop/index.js
@@ -15,6 +15,21 @@ const Shop = ({ shop, distance }) => {
 
     return `${chain} @ ${title}`;
   };
+  function openMapApp(shopCoordinates) {
+    const isAppleOS = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i)?true:false;
+    const isWindows = navigator.platform.match(/(Win)/i)?true:false;
+
+    // Open Apple Maps if OS is iOS/macOS
+    if (isAppleOS) {
+      return `maps:?daddr=${shopCoordinates}`; 
+    }
+    // Open Bing Maps if OS is Windows
+    if (isWindows) {
+      return `http://bing.com/maps/default.aspx?rtp=~adr.${shopCoordinates}`;
+    }
+    // Open Google Maps app on Android or web on other platforms not listed
+    return `https://www.google.com/maps/search/?api=1&query=${shopCoordinates}`;
+  }
 
   const shopCoordinates = `${shop.location.LATITUDE},${shop.location.LONGITUDE}`;
 
@@ -25,7 +40,7 @@ const Shop = ({ shop, distance }) => {
       </h2>
       <a
         className="shop__address"
-        href={navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? `maps:?daddr=${shopCoordinates}` : `geo:?daddr=${shopCoordinates}`}
+        href={openMapApp(shopCoordinates)}
         target="_system"
       >
         {shop.address}

--- a/src/components/Shop/index.js
+++ b/src/components/Shop/index.js
@@ -28,7 +28,7 @@ const Shop = ({ shop, distance }) => {
       return `http://bing.com/maps/default.aspx?rtp=~adr.${shopCoordinates}`;
     }
     // Open Google Maps app on Android or web on other platforms not listed
-    return `https://www.google.com/maps/search/?api=1&query=${shopCoordinates}`;
+    return `https://www.google.com/maps/dir/?api=1&destination=${shopCoordinates}`;
   }
 
   const shopCoordinates = `${shop.location.LATITUDE},${shop.location.LONGITUDE}`;

--- a/src/components/Shop/index.js
+++ b/src/components/Shop/index.js
@@ -16,18 +16,14 @@ const Shop = ({ shop, distance }) => {
     return `${chain} @ ${title}`;
   };
   function openMapApp(shopCoordinates) {
-    const isAppleOS = navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i)?true:false;
-    const isWindows = navigator.platform.match(/(Win)/i)?true:false;
+    const isAppleOS = navigator.platform.match(/(iPhone|iPod|iPad)/i)?true:false;
 
-    // Open Apple Maps if OS is iOS/macOS
+    // Open Apple Maps if OS is iOS
     if (isAppleOS) {
-      return `maps:?daddr=${shopCoordinates}`; 
+      return `maps:?daddr=${shopCoordinates}`;
     }
-    // Open Bing Maps if OS is Windows
-    if (isWindows) {
-      return `http://bing.com/maps/default.aspx?rtp=~adr.${shopCoordinates}`;
-    }
-    // Open Google Maps app on Android or web on other platforms not listed
+
+    // Open Google Maps app/web on other platforms
     return `https://www.google.com/maps/dir/?api=1&destination=${shopCoordinates}`;
   }
 

--- a/src/components/Shop/index.js
+++ b/src/components/Shop/index.js
@@ -16,14 +16,20 @@ const Shop = ({ shop, distance }) => {
     return `${chain} @ ${title}`;
   };
 
+  const shopCoordinates = `${shop.location.LATITUDE},${shop.location.LONGITUDE}`;
+
   return (
     <div className="shop">
       <h2 className="shop__name">
         {formatName()}
       </h2>
-      <p className="shop__address">
+      <a
+        className="shop__address"
+        href={navigator.platform.match(/(Mac|iPhone|iPod|iPad)/i) ? `maps:?daddr=${shopCoordinates}` : `geo:?daddr=${shopCoordinates}`}
+        target="_system"
+      >
         {shop.address}
-      </p>
+      </a>
       {
         distance !== null ? (
           <p className="shop__distance">


### PR DESCRIPTION
This PR makes the shops' addresses links and sets a special `href` with their location coordinates.

See:
- http://tebros.com/2016/02/launching-external-maps-app-from-ionic2/
- https://stackoverflow.com/questions/10527983/best-way-to-detect-mac-os-x-or-windows-computers-with-javascript-or-jquery

Closes #2.