### PR TITLE
Update JSON url

### DIFF
--- a/src/components/ShopList/index.js
+++ b/src/components/ShopList/index.js
@@ -58,7 +58,7 @@ class ShopList extends Component {
   }
 
   async load() {
-    const shops = await fetch('https://bottleneckco.github.io/boba-scraper/data.json')
+    const shops = await fetch('https://bottleneckco.github.io/sg-scraper/data.json')
       .then((r) => r.json());
 
     this.setState({ shops: shops.filter((shop) => shop.location) });


### PR DESCRIPTION
# Purpose
The repo for boba-scraper was renamed, which changes the GitHub Pages URL. This fixes it.